### PR TITLE
Add support for fetching events and downloading associated media

### DIFF
--- a/src/api/download_event_thumbnail.rs
+++ b/src/api/download_event_thumbnail.rs
@@ -4,6 +4,8 @@ use reqwest::Client;
 use tokio::io::AsyncWriteExt;
 
 impl UnifiProtectServer {
+    // --- Thumbnail Downloading ---
+
     pub async fn download_event_thumbnail(
         &self,
         event_id: &str,
@@ -11,37 +13,45 @@ impl UnifiProtectServer {
         width: Option<u32>,
         height: Option<u32>,
     ) -> Result<(), Error> {
+        // Collect query parameters for width and height if provided
         let mut query_params = Vec::new();
-        if let Some(w) = width {
-            query_params.push(format!("w={}", w));
+        if let Some(width) = width {
+            query_params.push(format!("w={}", width));
         }
-        if let Some(h) = height {
-            query_params.push(format!("h={}", h));
+        if let Some(height) = height {
+            query_params.push(format!("h={}", height));
         }
 
+        // Build the query string
         let query_string = if query_params.is_empty() {
             "".to_string()
         } else {
             format!("?{}", query_params.join("&"))
         };
 
-        let endpoint = format!(
+        // Construct the full URL for the thumbnail request
+        let url = format!(
             "{}/proxy/protect/api/events/{}/thumbnail{}",
             self.uri, event_id, query_string
         );
 
+        // Build and send the HTTP GET request
         let mut response = Client::builder()
             .danger_accept_invalid_certs(true)
             .build()?
-            .get(&endpoint)
+            .get(&url)
             .headers(self.headers.clone())
             .send()
             .await?;
 
+        // Handle failure by reading the response text
         if !response.status().is_success() {
-            return Err(Error::ThumbnailDownloadFailed(format!("Status: {}", response.status())));
+            let status = response.status();
+            let text = response.text().await.unwrap_or_else(|_| "Could not read response text".to_string());
+            return Err(Error::ThumbnailDownloadFailed(format!("Status: {}, Body: {}", status, text)));
         }
 
+        // Create the output file and stream the response content into it
         let mut file = tokio::fs::File::create(output_path).await?;
 
         while let Some(chunk) = response.chunk().await? {

--- a/src/api/download_event_thumbnail.rs
+++ b/src/api/download_event_thumbnail.rs
@@ -46,9 +46,11 @@ impl UnifiProtectServer {
 
         // Handle failure by reading the response text
         if !response.status().is_success() {
-            let status = response.status();
-            let text = response.text().await.unwrap_or_else(|_| "Could not read response text".to_string());
-            return Err(Error::ThumbnailDownloadFailed(format!("Status: {}, Body: {}", status, text)));
+            return Err(Error::ThumbnailDownloadFailed(format!(
+                "Status: {}, Body: {}",
+                response.status(),
+                response.text().await.unwrap_or_else(|_| "Could not read response text".to_string())
+            )));
         }
 
         // Create the output file and stream the response content into it

--- a/src/api/download_event_thumbnail.rs
+++ b/src/api/download_event_thumbnail.rs
@@ -22,17 +22,16 @@ impl UnifiProtectServer {
             query_params.push(format!("h={}", height));
         }
 
-        // Build the query string
-        let query_string = if query_params.is_empty() {
-            "".to_string()
-        } else {
-            format!("?{}", query_params.join("&"))
-        };
-
-        // Construct the full URL for the thumbnail request
+        // Construct the full URL for the thumbnail request, including query parameters
         let url = format!(
             "{}/proxy/protect/api/events/{}/thumbnail{}",
-            self.uri, event_id, query_string
+            self.uri,
+            event_id,
+            if query_params.is_empty() {
+                "".to_string()
+            } else {
+                format!("?{}", query_params.join("&"))
+            }
         );
 
         // Build and send the HTTP GET request

--- a/src/api/download_event_thumbnail.rs
+++ b/src/api/download_event_thumbnail.rs
@@ -1,0 +1,53 @@
+use crate::UnifiProtectServer;
+use crate::error::Error;
+use reqwest::Client;
+use tokio::io::AsyncWriteExt;
+
+impl UnifiProtectServer {
+    pub async fn download_event_thumbnail(
+        &self,
+        event_id: &str,
+        output_path: &str,
+        width: Option<u32>,
+        height: Option<u32>,
+    ) -> Result<(), Error> {
+        let mut query_params = Vec::new();
+        if let Some(w) = width {
+            query_params.push(format!("w={}", w));
+        }
+        if let Some(h) = height {
+            query_params.push(format!("h={}", h));
+        }
+
+        let query_string = if query_params.is_empty() {
+            "".to_string()
+        } else {
+            format!("?{}", query_params.join("&"))
+        };
+
+        let endpoint = format!(
+            "{}/proxy/protect/api/events/{}/thumbnail{}",
+            self.uri, event_id, query_string
+        );
+
+        let mut response = Client::builder()
+            .danger_accept_invalid_certs(true)
+            .build()?
+            .get(&endpoint)
+            .headers(self.headers.clone())
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(Error::ThumbnailDownloadFailed(format!("Status: {}", response.status())));
+        }
+
+        let mut file = tokio::fs::File::create(output_path).await?;
+
+        while let Some(chunk) = response.chunk().await? {
+            file.write_all(&chunk).await?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/api/download_footage.rs
+++ b/src/api/download_footage.rs
@@ -6,6 +6,8 @@ use reqwest::Client;
 use tokio::io::AsyncWriteExt;
 
 impl UnifiProtectServer {
+    // --- Footage Downloading ---
+
     pub async fn download_footage(
         &self,
         camera: &UnifiProtectCameraSimple,
@@ -14,6 +16,7 @@ impl UnifiProtectServer {
         start_unix: i64,
         end_unix: i64,
     ) -> Result<bool, Error> {
+        // Construct the API endpoint with all necessary parameters
         for channel in 0..4 {
             let endpoint = format!(
                 "{}/proxy/protect/api/video/export?camera={}                {}                &channel={}                &filename={}.mp4                &lens=0                &start={}                &end={}                &type={}",
@@ -31,6 +34,7 @@ impl UnifiProtectServer {
                 recording_type
             );
 
+            // Execute the request
             let mut response = Client::builder()
                 .danger_accept_invalid_certs(true)
                 .build()?
@@ -39,6 +43,7 @@ impl UnifiProtectServer {
                 .send()
                 .await?;
 
+            // Handle non-success status codes
             if !response.status().is_success() {
                 let status_code = response.status();
                 let error_msg = response.json::<ErrorResponse>().await.ok().map(|x| x.error);
@@ -53,6 +58,7 @@ impl UnifiProtectServer {
                 }
             }
 
+            // Stream the response body to the specified file
             let mut file = tokio::fs::File::create(output_path).await?;
 
             while let Some(chunk) = response.chunk().await? {
@@ -65,6 +71,8 @@ impl UnifiProtectServer {
         Ok(false)
     }
 
+    // --- Event-specific Footage Downloading ---
+
     pub async fn download_event_footage(
         &self,
         camera: &UnifiProtectCameraSimple,
@@ -74,9 +82,11 @@ impl UnifiProtectServer {
         pre_padding_seconds: u64,
         post_padding_seconds: u64,
     ) -> Result<bool, Error> {
+        // Calculate the adjusted start and end times with padding
         let start_unix = event.start / 1000 - pre_padding_seconds as i64;
         let end_unix = event.end / 1000 + post_padding_seconds as i64;
 
+        // Delegate to the main download_footage method
         self.download_footage(camera, output_path, recording_type, start_unix, end_unix).await
     }
 }

--- a/src/api/download_footage.rs
+++ b/src/api/download_footage.rs
@@ -1,4 +1,5 @@
 use crate::camera::UnifiProtectCameraSimple;
+use crate::event::MotionEvent;
 use crate::{ErrorResponse, UnifiProtectServer};
 use crate::error::Error;
 use reqwest::Client;
@@ -15,14 +16,7 @@ impl UnifiProtectServer {
     ) -> Result<bool, Error> {
         for channel in 0..4 {
             let endpoint = format!(
-                "{}/proxy/protect/api/video/export?camera={}\
-                {}\
-                &channel={}\
-                &filename={}.mp4\
-                &lens=0\
-                &start={}\
-                &end={}\
-                &type={}",
+                "{}/proxy/protect/api/video/export?camera={}                {}                &channel={}                &filename={}.mp4                &lens=0                &start={}                &end={}                &type={}",
                 self.uri,
                 camera.id,
                 (if recording_type == "timelapse" {
@@ -69,5 +63,20 @@ impl UnifiProtectServer {
         }
 
         Ok(false)
+    }
+
+    pub async fn download_event_footage(
+        &self,
+        camera: &UnifiProtectCameraSimple,
+        event: &MotionEvent,
+        output_path: &str,
+        recording_type: &str,
+        pre_padding_seconds: u64,
+        post_padding_seconds: u64,
+    ) -> Result<bool, Error> {
+        let start_unix = event.start / 1000 - pre_padding_seconds as i64;
+        let end_unix = event.end / 1000 + post_padding_seconds as i64;
+
+        self.download_footage(camera, output_path, recording_type, start_unix, end_unix).await
     }
 }

--- a/src/api/fetch_events.rs
+++ b/src/api/fetch_events.rs
@@ -3,6 +3,8 @@ use crate::error::Error;
 use reqwest::Client;
 
 impl UnifiProtectServer {
+    // --- Event Fetching ---
+
     pub async fn fetch_events(
         &self,
         camera_id: &str,
@@ -10,16 +12,19 @@ impl UnifiProtectServer {
         end_unix_ms: i64,
         types: Option<Vec<&str>>,
     ) -> Result<Vec<UnifiProtectEvent>, Error> {
+        // Prepare the event types query parameter
         let types_str = match types {
             Some(t) => format!("&types={}", t.join(",")),
             None => "".to_string(),
         };
 
+        // Construct the full API endpoint URL
         let endpoint = format!(
-            "{}/proxy/protect/api/events?cameras={}&start={}&end={}{}&withoutDescriptions=true",
+            "{}/proxy/protect/api/events?cameras={}            &start={}            &end={}            {}            &withoutDescriptions=true",
             self.uri, camera_id, start_unix_ms, end_unix_ms, types_str
         );
 
+        // Build and send the HTTP request
         let response = Client::builder()
             .danger_accept_invalid_certs(true)
             .build()?
@@ -28,11 +33,12 @@ impl UnifiProtectServer {
             .send()
             .await?;
 
+        // Check for API errors
         if !response.status().is_success() {
             return Err(Error::EventFetchFailed(format!("Status: {}", response.status())));
         }
 
-        let events: Vec<UnifiProtectEvent> = response.json().await?;
-        Ok(events)
+        // Parse and return the event list
+        Ok(response.json().await?)
     }
 }

--- a/src/api/fetch_events.rs
+++ b/src/api/fetch_events.rs
@@ -1,0 +1,38 @@
+use crate::{UnifiProtectEvent, UnifiProtectServer};
+use crate::error::Error;
+use reqwest::Client;
+
+impl UnifiProtectServer {
+    pub async fn fetch_events(
+        &self,
+        camera_id: &str,
+        start_unix_ms: i64,
+        end_unix_ms: i64,
+        types: Option<Vec<&str>>,
+    ) -> Result<Vec<UnifiProtectEvent>, Error> {
+        let types_str = match types {
+            Some(t) => format!("&types={}", t.join(",")),
+            None => "".to_string(),
+        };
+
+        let endpoint = format!(
+            "{}/proxy/protect/api/events?cameras={}&start={}&end={}{}&withoutDescriptions=true",
+            self.uri, camera_id, start_unix_ms, end_unix_ms, types_str
+        );
+
+        let response = Client::builder()
+            .danger_accept_invalid_certs(true)
+            .build()?
+            .get(&endpoint)
+            .headers(self.headers.clone())
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(Error::EventFetchFailed(format!("Status: {}", response.status())));
+        }
+
+        let events: Vec<UnifiProtectEvent> = response.json().await?;
+        Ok(events)
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,7 +1,13 @@
 mod download_footage;
 mod fetch_cameras;
+mod fetch_events;
+mod download_event_thumbnail;
 
 #[allow(unused_imports)]
 pub use download_footage::*;
 #[allow(unused_imports)]
 pub use fetch_cameras::*;
+#[allow(unused_imports)]
+pub use fetch_events::*;
+#[allow(unused_imports)]
+pub use download_event_thumbnail::*;

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,12 @@ pub enum Error {
     #[error("failed to download footage: {0}")]
     DownloadFailed(String),
 
+    #[error("failed to fetch events: {0}")]
+    EventFetchFailed(String),
+
+    #[error("failed to download thumbnail: {0}")]
+    ThumbnailDownloadFailed(String),
+
     #[error("other error: {0}")]
     Other(String),
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct MotionEvent {
+    pub id: String,
+    pub model_key: String,
+    pub start: i64,
+    pub end: i64,
+    pub score: i32,
+    pub smart_detect_types: Vec<String>,
+    pub camera: String,
+    pub partition: Option<serde_json::Value>,
+    pub user: Option<String>,
+    pub metadata: MotionEventMetadata,
+    pub thumbnail: Option<String>,
+    pub heatmap: Option<String>,
+    pub timestamp: i64,
+    pub is_favorite: bool,
+    pub favorite_object_ids: Option<Vec<String>>,
+    pub category: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct MotionEventMetadata {
+    pub ram_description: Option<String>,
+    pub detected_thumbnails: Option<Vec<DetectedThumbnail>>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct DetectedThumbnail {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub cropped_id: String,
+    pub confidence: i32,
+    pub clock_best_wall: i64,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum UnifiProtectEvent {
+    Motion(MotionEvent),
+    #[serde(other)]
+    Unknown,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,10 @@ pub mod error;
 pub mod api;
 pub mod auth;
 pub mod camera;
+pub mod event;
 
 pub use crate::error::Error;
+pub use crate::event::*;
 use crate::camera::*;
 use reqwest::header::HeaderMap;
 

--- a/tests/test_events.rs
+++ b/tests/test_events.rs
@@ -1,0 +1,62 @@
+use unifi_protect::UnifiProtectEvent;
+
+#[test]
+fn test_parse_motion_event() {
+    let event_json = r#"{
+        "id": "fa23a1d1-4d29-4c5a-a8a6-4d52df3c5739",
+        "modelKey": "event",
+        "type": "motion",
+        "start": 1776698709469,
+        "end": 1776698757185,
+        "score": 100,
+        "smartDetectTypes": [],
+        "camera": "657bb728023b9303e4000508",
+        "partition": null,
+        "user": null,
+        "metadata": {
+            "ramDescription": "",
+            "detectedThumbnails": [
+                {
+                    "type": "motion",
+                    "croppedId": "D021F9956ADD-1776698758594",
+                    "confidence": 100,
+                    "clockBestWall": 1776698734205
+                }
+            ]
+        },
+        "thumbnail": "e-fa23a1d1-4d29-4c5a-a8a6-4d52df3c5739",
+        "heatmap": "e-fa23a1d1-4d29-4c5a-a8a6-4d52df3c5739",
+        "timestamp": 1776698733327,
+        "isFavorite": false,
+        "favoriteObjectIds": null,
+        "category": "motion"
+    }"#;
+
+    let event: UnifiProtectEvent = serde_json::from_str(event_json).expect("Failed to parse event");
+
+    if let UnifiProtectEvent::Motion(motion_event) = event {
+        assert_eq!(motion_event.id, "fa23a1d1-4d29-4c5a-a8a6-4d52df3c5739");
+        assert_eq!(motion_event.score, 100);
+        assert_eq!(motion_event.camera, "657bb728023b9303e4000508");
+        assert_eq!(motion_event.metadata.detected_thumbnails.unwrap().len(), 1);
+    } else {
+        panic!("Expected Motion event");
+    }
+}
+
+#[test]
+fn test_parse_unknown_event() {
+    let event_json = r#"{
+        "id": "unknown-id",
+        "type": "someOtherType",
+        "start": 123,
+        "end": 456
+    }"#;
+
+    let event: UnifiProtectEvent = serde_json::from_str(event_json).expect("Failed to parse event");
+
+    match event {
+        UnifiProtectEvent::Unknown => (),
+        _ => panic!("Expected Unknown event"),
+    }
+}


### PR DESCRIPTION
This change expands the library to support fetching UniFi Protect events. 
Specifically:
- Defined UnifiProtectEvent and MotionEvent structures.
- Implemented fetch_events to retrieve event metadata from the API.
- Implemented download_event_thumbnail to download event-specific images.
- Implemented download_event_footage to download video clips for events, including support for pre and post padding.
- Added unit tests to verify JSON parsing of event data.
- Updated error types to include event-related failures.

---
*PR created automatically by Jules for task [4887749500542906325](https://jules.google.com/task/4887749500542906325) started by @larsfroelich*